### PR TITLE
Update truncation message in open_ai_tools_execution

### DIFF
--- a/utils/llm.py
+++ b/utils/llm.py
@@ -81,8 +81,10 @@ def open_ai_tools_execution(tool_manager: ToolManager, tools: List[Dict[str, Any
 
             # Check if the response is longer than 7000 characters
             if len(function_response_str) > 7000:
-                function_response_str = function_response_str[
-                                        :7000] + " RESPONSE IS CUTTED BECAUSE OF MORE THAN 1000 CHARS"
+                function_response_str = (
+                    function_response_str[:7000]
+                    + " RESPONSE TRUNCATED BECAUSE IT EXCEEDED 7000 CHARS"
+                )
 
             # Format the successful response
             response = {


### PR DESCRIPTION
## Summary
- update the truncation warning in `open_ai_tools_execution` to note the 7000 character limit

## Testing
- `python -m py_compile utils/llm.py`